### PR TITLE
Add a HomeBrew formula

### DIFF
--- a/Formula/super-calc.rb
+++ b/Formula/super-calc.rb
@@ -1,0 +1,17 @@
+class SuperCalc < Formula
+  desc "SuperCalc is a mathematical expression parser & evaluator, plus more"
+  homepage "https://github.com/ctrezevant/SuperCalc"
+  url "https://github.com/ctrezevant/SuperCalc.git"
+  version "1.0.0"
+
+  def install
+    system "./autogen.sh"
+    system "./configure"
+    system "make"
+    bin.install "sc"
+  end
+
+  test do
+    system "#{bin}/sc"
+  end
+end

--- a/Formula/super-calc.rb
+++ b/Formula/super-calc.rb
@@ -1,10 +1,10 @@
 class SuperCalc < Formula
   desc "SuperCalc is a mathematical expression parser & evaluator, plus more"
-  homepage "https://github.com/ctrezevant/SuperCalc"
-  url "https://github.com/ctrezevant/SuperCalc.git"
+  homepage "https://github.com/C0deH4cker/SuperCalc"
+  url "https://github.com/C0deH4cker/SuperCalc.git"
   version "1.0.0"
  
-  # Needed to override Brew's Superenv
+  # Needed to override Brew's Superenv, which was breaking our build
   env :std
 
   def install

--- a/Formula/super-calc.rb
+++ b/Formula/super-calc.rb
@@ -3,6 +3,9 @@ class SuperCalc < Formula
   homepage "https://github.com/ctrezevant/SuperCalc"
   url "https://github.com/ctrezevant/SuperCalc.git"
   version "1.0.0"
+ 
+  # Needed to override Brew's Superenv
+  env :std
 
   def install
     system "./autogen.sh"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#SuperCalc
+# SuperCalc
 
-#####A mathematical expression parser and evaluator plus more.
+##### A mathematical expression parser and evaluator, plus more.
 
 Currently, SuperCalc supports the following binary operators:
 
@@ -205,7 +205,7 @@ Examples using `map`:
 	<0, 1.5707963267949, 3.14159265358979, 4.71238898038469, 6.28318530717959>
 	sc> map(sin, angles)
 	<0, 1, 0, -1, 0>
-	sc> 
+	sc>
 	sc> map(add1, map(sqrt, <1, 4, 9, 16, 20, 16/9>))
 	<2, 3, 4, 5, 5.472add1(x) = 1 + x13595499958, 7/3>
 
@@ -384,10 +384,21 @@ Examples of printing functions verbosely:
 	  </func>
 	</vardata>
 
-##Building
+
+## Installation
+
+##### With Homebrew (on macOS)
+
+```
+  $ brew tap C0deH4cker/SuperCalc https://github.com/C0deH4cker/SuperCalc.git && brew install super-calc
+```
+
+##### Building Manually
 
 To build on Linux or Mac OS X, you can use Automake and Autoconf:
 
+```
 	$ ./autogen.sh
 	$ ./configure
 	$ make
+```


### PR DESCRIPTION
This adds an easy method for macOS users to install SuperCalc. 

Now, installation is as simple as:

```
brew tap C0deH4cker/SuperCalc https://github.com/C0deH4cker/SuperCalc.git && brew install super-calc
```

Additionally, updates to SuperCalc will be automatically built and installed as the repository is updated, whenever `brew update` is run.

In the future, it may be useful to include generate a release and point the formula to it, although it isn't strictly necessary (as I have discovered!). This version of the formula will build SuperCalc at whatever the current `HEAD` of the `master` branch might be.

Enjoy!